### PR TITLE
Add PayPal to adopter list

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -533,6 +533,11 @@ landscape:
             logo: newrelic.svg
             crunchbase: 'https://www.crunchbase.com/organization/new-relic'
           - item:
+            name: PayPal (adopter)
+            homepage_url: 'https://paypal.com/'
+            logo: paypal.svg
+            crunchbase: 'https://www.crunchbase.com/organization/paypal'
+          - item:
             name: Pinterest (adopter)
             homepage_url: 'https://www.pinterest.com/'
             logo: pinterest.svg


### PR DESCRIPTION
Extending the existing member entry to be included in the adopter list as well using the same data and logo already included in PayPal's member entry.