### PR TITLE
fix(tools): TypeGraphQL homepage URL links to a suspicious website

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -102,7 +102,7 @@ landscape:
             crunchbase: https://www.crunchbase.com/organization/dailymotion
           - item:
             name: TypeGraphQL
-            homepage_url: https://typegraphql.ml
+            homepage_url: https://typegraphql.com
             repo_url: https://github.com/MichalLytek/type-graphql
             logo: type-graphql.svg
             crunchbase: https://www.crunchbase.com/organization/typegraphql


### PR DESCRIPTION
https://typegraphql.ml [**NSFW**] definitely does not seem to be the right TLD anymore.